### PR TITLE
Fix LLM tool selection default values and error handling

### DIFF
--- a/app/api/tools/llm/groq.ts
+++ b/app/api/tools/llm/groq.ts
@@ -3,6 +3,13 @@ import { generateObject } from 'ai';
 import { z } from 'zod';
 import { Tool } from '../types';
 
+// Default values for GitHub tools
+const DEFAULTS = {
+  owner: 'OpenAgentsInc',
+  repo: 'snowball',
+  branch: 'main'
+};
+
 export async function selectTool(intent: string, tools: Tool[]) {
   const model = groq('llama-3.3-70b-versatile');
   
@@ -42,8 +49,21 @@ Think through this step by step:
 1. What is the user trying to do?
 2. Which tool best matches this intent?
 3. What parameters can be extracted from the intent?
-4. How confident are you in this selection?`
+4. How confident are you in this selection?
+
+Note: For GitHub operations, if owner/repo/branch are not specified:
+- Default owner: ${DEFAULTS.owner}
+- Default repo: ${DEFAULTS.repo}
+- Default branch: ${DEFAULTS.branch}`
   });
+
+  // Apply defaults for GitHub tools
+  if (object.tool.startsWith('view_')) {
+    object.parameters = {
+      ...DEFAULTS,
+      ...object.parameters
+    };
+  }
 
   return object;
 }
@@ -71,7 +91,12 @@ Check:
 2. Are all required parameters present and valid?
 3. Do the parameter values make sense for the intent?
 
-If validation fails, suggest how the user could rephrase their request.`,
+If validation fails, suggest how the user could rephrase their request.
+
+Note: For GitHub operations, these defaults are acceptable:
+- Owner: ${DEFAULTS.owner}
+- Repo: ${DEFAULTS.repo}
+- Branch: ${DEFAULTS.branch}`,
     prompt: `User intent: "${intent}"
 
 Selected tool: ${selectedTool}

--- a/app/api/tools/route/route.ts
+++ b/app/api/tools/route/route.ts
@@ -89,17 +89,46 @@ export async function POST(request: Request) {
       );
     }
 
-    // Execute the tool
-    const result = await toolHandler(parameters);
+    try {
+      // Execute the tool
+      const result = await toolHandler(parameters);
 
-    // Log the response
-    const response = { result };
-    console.log('\n=== RESPONSE ===');
-    console.log(JSON.stringify(response, null, 2));
-    console.log('=== END RESPONSE ===\n');
+      // Log the response
+      const response = { result };
+      console.log('\n=== RESPONSE ===');
+      console.log(JSON.stringify(response, null, 2));
+      console.log('=== END RESPONSE ===\n');
 
-    // Return the result
-    return NextResponse.json(response);
+      // Return the result
+      return NextResponse.json(response);
+    } catch (error: any) {
+      // Handle tool execution errors
+      console.error('\n=== TOOL ERROR ===');
+      console.error('Error executing tool:', error);
+      console.error('=== END TOOL ERROR ===\n');
+
+      const message = error.message || 'Error executing tool';
+      
+      // Handle specific error cases
+      if (message.includes('not publicly accessible')) {
+        return NextResponse.json({
+          error: `I can't access that ${tool === 'view_file' ? 'file' : 'folder'}. Please check the path and try again.`,
+          parameters
+        }, { status: 403 });
+      }
+      if (message.includes('not found')) {
+        return NextResponse.json({
+          error: `I couldn't find that ${tool === 'view_file' ? 'file' : 'folder'}. Please check the path and try again.`,
+          parameters
+        }, { status: 404 });
+      }
+
+      // Generic error
+      return NextResponse.json({
+        error: message,
+        parameters
+      }, { status: 500 });
+    }
 
   } catch (error: any) {
     // Log the error


### PR DESCRIPTION
# Fix LLM Tool Selection Default Values

This PR fixes issues with the LLM-based tool selection system by properly handling default values and improving error handling.

## Changes

### 1. Added Default Values
In `app/api/tools/llm/groq.ts`:
- Added `DEFAULTS` constant for GitHub tools
- Updated LLM prompts to include default values
- Added automatic default value application for view_* tools
- Updated validation to accept default values

### 2. Improved Error Handling
In `app/api/tools/route/route.ts`:
- Added specific error handling for tool execution
- Better error messages for access and not found errors
- Included parameters in error responses
- Separated tool execution errors from general errors

## Example Usage

Before:
```
Intent: "view the contents of the docs folder"
Error: "Attempted access to unauthorized repo: undefined/undefined"
```

After:
```
Intent: "view the contents of the docs folder"
Parameters: {
  path: "docs",
  owner: "OpenAgentsInc",
  repo: "snowball",
  branch: "main"
}
Result: [folder contents]
```

## Testing

The changes have been tested with:
1. Basic file/folder viewing
2. Missing parameters (defaults applied)
3. Invalid paths
4. Unauthorized access
5. Not found errors

## Error Messages

Now provides clearer error messages:
- "I can't access that folder. Please check the path and try again."
- "I couldn't find that file. Please check the path and try again."
- Includes the attempted parameters in error responses

Fixes #11