### PR TITLE
Fix file path normalization for common files

### DIFF
--- a/app/api/tools/llm/groq.ts
+++ b/app/api/tools/llm/groq.ts
@@ -10,6 +10,47 @@ const DEFAULTS = {
   branch: 'main'
 };
 
+// Common file mappings
+const COMMON_FILES = {
+  readme: 'README.md',
+  'readme.md': 'README.md',
+  'readme.markdown': 'README.md',
+  package: 'package.json',
+  'package.json': 'package.json',
+  license: 'LICENSE',
+  'license.md': 'LICENSE',
+  'license.txt': 'LICENSE'
+};
+
+function normalizeFilePath(path: string): string {
+  // Convert to lowercase for matching
+  const lower = path.toLowerCase();
+  
+  // Check common file mappings
+  for (const [key, value] of Object.entries(COMMON_FILES)) {
+    if (lower === key) {
+      return value;
+    }
+  }
+
+  // If it's a README variant without extension, add .md
+  if (lower === 'readme' || lower.startsWith('readme.')) {
+    return 'README.md';
+  }
+
+  // If it's a package.json variant
+  if (lower === 'package' || lower.startsWith('package.')) {
+    return 'package.json';
+  }
+
+  // If it's a license variant
+  if (lower === 'license' || lower.startsWith('license.')) {
+    return 'LICENSE';
+  }
+
+  return path;
+}
+
 export async function selectTool(intent: string, tools: Tool[]) {
   const model = groq('llama-3.3-70b-versatile');
   
@@ -36,7 +77,14 @@ Be conservative with confidence scores:
 - 0.5-0.7 = Understand the intent but unsure if tool/params are right
 - <0.5 = High uncertainty or unable to map intent to tools
 
-Format parameters according to the tool's schema exactly.`,
+Format parameters according to the tool's schema exactly.
+
+Special handling for common files:
+- README -> README.md
+- package.json -> package.json
+- LICENSE -> LICENSE
+
+Always include the file extension when specifying a path.`,
     prompt: `Available tools:
 ${tools.map(t => `- ${t.name}: ${t.description}
   Parameters: ${Object.entries(t.parameters).map(([k,v]) => `${k}: ${v.description} (${v.required ? 'required' : 'optional'})`).join(', ')}`).join('\n')}
@@ -54,15 +102,23 @@ Think through this step by step:
 Note: For GitHub operations, if owner/repo/branch are not specified:
 - Default owner: ${DEFAULTS.owner}
 - Default repo: ${DEFAULTS.repo}
-- Default branch: ${DEFAULTS.branch}`
+- Default branch: ${DEFAULTS.branch}
+
+Remember to include file extensions in paths (e.g., README.md, not just README).`
   });
 
-  // Apply defaults for GitHub tools
+  // Apply defaults and normalize paths for GitHub tools
   if (object.tool.startsWith('view_')) {
+    // Apply defaults first
     object.parameters = {
       ...DEFAULTS,
       ...object.parameters
     };
+
+    // Normalize file path if it's a file view
+    if (object.tool === 'view_file' && object.parameters.path) {
+      object.parameters.path = normalizeFilePath(object.parameters.path);
+    }
   }
 
   return object;
@@ -90,6 +146,7 @@ Check:
 1. Does the selected tool match the user's intent?
 2. Are all required parameters present and valid?
 3. Do the parameter values make sense for the intent?
+4. For files, are proper extensions included (e.g., README.md not README)?
 
 If validation fails, suggest how the user could rephrase their request.
 


### PR DESCRIPTION
# Fix File Path Normalization

This PR fixes issues with file path handling, particularly for common files like README.md, package.json, and LICENSE.

## Problem
The LLM was returning incomplete file paths:
- "README" instead of "README.md"
- "package" instead of "package.json"
- Inconsistent casing (readme.md vs README.md)

## Solution

Added path normalization in `app/api/tools/llm/groq.ts`:

1. Common File Mappings:
```typescript
const COMMON_FILES = {
  readme: 'README.md',
  'readme.md': 'README.md',
  'readme.markdown': 'README.md',
  package: 'package.json',
  'package.json': 'package.json',
  license: 'LICENSE',
  'license.md': 'LICENSE',
  'license.txt': 'LICENSE'
};
```

2. Path Normalization Function:
```typescript
function normalizeFilePath(path: string): string {
  // Convert to lowercase for matching
  const lower = path.toLowerCase();
  
  // Check common file mappings
  for (const [key, value] of Object.entries(COMMON_FILES)) {
    if (lower === key) {
      return value;
    }
  }

  // Handle README variants
  if (lower === 'readme' || lower.startsWith('readme.')) {
    return 'README.md';
  }

  // Handle package.json variants
  if (lower === 'package' || lower.startsWith('package.')) {
    return 'package.json';
  }

  // Handle license variants
  if (lower === 'license' || lower.startsWith('license.')) {
    return 'LICENSE';
  }

  return path;
}
```

3. Updated LLM Prompts:
- Added instructions about file extensions
- Added examples of proper file paths
- Improved validation checks

## Testing

Tested with various inputs:
- "read the README file" -> README.md
- "show me readme" -> README.md
- "what's in package.json" -> package.json
- "view package" -> package.json
- "check the license" -> LICENSE

## Example

Before:
```
Intent: "read the README file"
Path: "README" -> Error: File not found
```

After:
```
Intent: "read the README file"
Path: "README.md" -> Success
```