### PR TITLE
Simplify GitHub path checks

### DIFF
--- a/app/api/tools/utils/github.ts
+++ b/app/api/tools/utils/github.ts
@@ -7,21 +7,6 @@ export function validateGitHubToken() {
   return token;
 }
 
-// Allowed repositories and paths
-const ALLOWED_REPOS = {
-  'OpenAgentsInc/snowball': {
-    allowedPaths: [
-      'README.md',
-      'package.json',
-      'docs/',
-      'components/',
-      'app/',
-      'tools/'
-    ],
-    publicBranches: ['main']
-  }
-};
-
 // Check if a path is allowed
 export function isAllowedPath(owner: string, repo: string, filepath: string, branch: string): boolean {
   if (!filepath) {
@@ -29,23 +14,11 @@ export function isAllowedPath(owner: string, repo: string, filepath: string, bra
     return false;
   }
 
-  const repoKey = `${owner}/${repo}`;
-  const repoConfig = ALLOWED_REPOS[repoKey as keyof typeof ALLOWED_REPOS];
-  
-  if (!repoConfig) {
-    console.warn(`Attempted access to unauthorized repo: ${repoKey}`);
+  // Only allow access to OpenAgentsInc/snowball on main branch
+  if (owner !== 'OpenAgentsInc' || repo !== 'snowball' || branch !== 'main') {
+    console.warn(`Attempted access to unauthorized repo/branch: ${owner}/${repo}@${branch}`);
     return false;
   }
 
-  if (!repoConfig.publicBranches.includes(branch)) {
-    console.warn(`Attempted access to unauthorized branch: ${branch} in ${repoKey}`);
-    return false;
-  }
-
-  return repoConfig.allowedPaths.some(allowedPath => {
-    if (allowedPath.endsWith('/')) {
-      return filepath.startsWith(allowedPath);
-    }
-    return filepath === allowedPath;
-  });
+  return true;
 }


### PR DESCRIPTION
# Simplify GitHub Path Checks

This PR simplifies the GitHub path checking logic by removing the strict path allowlist and just enforcing repository and branch restrictions.

## Changes

Simplified `app/api/tools/utils/github.ts`:
1. Removed `ALLOWED_REPOS` constant with path allowlist
2. Simplified `isAllowedPath` to only check:
   - Valid filepath provided
   - Repository is OpenAgentsInc/snowball
   - Branch is main

## Before
```typescript
const ALLOWED_REPOS = {
  'OpenAgentsInc/snowball': {
    allowedPaths: [
      'README.md',
      'package.json',
      'docs/',
      'components/',
      'app/',
      'tools/'
    ],
    publicBranches: ['main']
  }
};

// Complex path checking against allowlist
return repoConfig.allowedPaths.some(allowedPath => {
  if (allowedPath.endsWith('/')) {
    return filepath.startsWith(allowedPath);
  }
  return filepath === allowedPath;
});
```

## After
```typescript
// Simple repo/branch check
if (owner !== 'OpenAgentsInc' || repo !== 'snowball' || branch !== 'main') {
  console.warn(`Attempted access to unauthorized repo/branch: ${owner}/${repo}@${branch}`);
  return false;
}

return true;
```

## Why
- The path allowlist was too restrictive
- We want to allow access to any file in the repo
- The repo/branch restrictions provide sufficient security
- Simpler code is easier to maintain

## Testing
Tested with:
- Various file paths that were previously blocked
- Different repo/branch combinations
- Missing filepath cases