### PR TITLE
Fix file path selection defaulting to README.md

### DIFF
--- a/app/api/tools/llm/groq.ts
+++ b/app/api/tools/llm/groq.ts
@@ -22,9 +22,21 @@ const COMMON_FILES = {
   'license.txt': 'LICENSE'
 };
 
-function normalizeFilePath(path: string): string {
+function normalizeFilePath(path: string, originalIntent: string): string {
+  // If path contains a directory separator, treat it as an explicit path
+  if (path.includes('/')) {
+    return path;
+  }
+
   // Convert to lowercase for matching
   const lower = path.toLowerCase();
+  
+  // Check if the original intent contained an explicit path
+  const intentPath = originalIntent.match(/['"](.*?)['"]/)?.[1] || 
+                    originalIntent.match(/([\w-]+\/[\w-]+\.[\w]+)/)?.[1];
+  if (intentPath) {
+    return intentPath;
+  }
   
   // Check common file mappings
   for (const [key, value] of Object.entries(COMMON_FILES)) {
@@ -71,6 +83,11 @@ Your task is to:
 4. Provide reasoning for your selection
 5. Assign a confidence score (0-1) for your selection
 
+IMPORTANT: When a specific file path is provided (e.g., "docs/file.md" or "src/components/Button.tsx"):
+- Use the exact path as provided
+- Do not default to README.md or other common files
+- Maintain the original path structure and file extension
+
 Be conservative with confidence scores:
 - 0.9+ = Almost certain this is the right tool and parameters
 - 0.7-0.9 = Fairly confident but there might be some ambiguity
@@ -79,7 +96,7 @@ Be conservative with confidence scores:
 
 Format parameters according to the tool's schema exactly.
 
-Special handling for common files:
+Special handling for common files (ONLY when no specific path is provided):
 - README -> README.md
 - package.json -> package.json
 - LICENSE -> LICENSE
@@ -104,8 +121,19 @@ Note: For GitHub operations, if owner/repo/branch are not specified:
 - Default repo: ${DEFAULTS.repo}
 - Default branch: ${DEFAULTS.branch}
 
-Remember to include file extensions in paths (e.g., README.md, not just README).`
+Remember:
+- If a specific file path is provided, use it exactly as given
+- Only normalize common files like README when no specific path is given
+- Always include file extensions in paths`
   });
+
+  // Log the LLM's selection
+  console.log('\n=== LLM TOOL SELECTION ===');
+  console.log('Intent:', intent);
+  console.log('Selected tool:', object.tool);
+  console.log('Initial parameters:', object.parameters);
+  console.log('Confidence:', object.confidence);
+  console.log('Reasoning:', object.reasoning);
 
   // Apply defaults and normalize paths for GitHub tools
   if (object.tool.startsWith('view_')) {
@@ -117,9 +145,18 @@ Remember to include file extensions in paths (e.g., README.md, not just README).
 
     // Normalize file path if it's a file view
     if (object.tool === 'view_file' && object.parameters.path) {
-      object.parameters.path = normalizeFilePath(object.parameters.path);
+      const originalPath = object.parameters.path;
+      object.parameters.path = normalizeFilePath(object.parameters.path, intent);
+      
+      // Log path normalization
+      if (originalPath !== object.parameters.path) {
+        console.log('Path normalized:', originalPath, '->', object.parameters.path);
+      }
     }
   }
+
+  console.log('Final parameters:', object.parameters);
+  console.log('=== END TOOL SELECTION ===\n');
 
   return object;
 }
@@ -146,7 +183,10 @@ Check:
 1. Does the selected tool match the user's intent?
 2. Are all required parameters present and valid?
 3. Do the parameter values make sense for the intent?
-4. For files, are proper extensions included (e.g., README.md not README)?
+4. For files, verify paths are handled correctly:
+   - Explicit paths (e.g., "docs/file.md") should be preserved exactly
+   - Only normalize common files (README, LICENSE) when no specific path given
+   - Always ensure proper file extensions
 
 If validation fails, suggest how the user could rephrase their request.
 

--- a/app/api/tools/route/route.ts
+++ b/app/api/tools/route/route.ts
@@ -13,7 +13,7 @@ const handlers = {
 export async function POST(request: Request) {
   try {
     // Log all request details
-    console.log('\n=== ELEVENLABS TOOL REQUEST ===');
+    console.log('\n=== TOOL REQUEST ===');
     console.log('Timestamp:', new Date().toISOString());
     
     // Log headers
@@ -90,6 +90,11 @@ export async function POST(request: Request) {
     }
 
     try {
+      // Log tool execution attempt
+      console.log('\n=== EXECUTING TOOL ===');
+      console.log('Tool:', tool);
+      console.log('Parameters:', parameters);
+      
       // Execute the tool
       const result = await toolHandler(parameters);
 
@@ -105,6 +110,8 @@ export async function POST(request: Request) {
       // Handle tool execution errors
       console.error('\n=== TOOL ERROR ===');
       console.error('Error executing tool:', error);
+      console.error('Tool:', tool);
+      console.error('Parameters:', parameters);
       console.error('=== END TOOL ERROR ===\n');
 
       const message = error.message || 'Error executing tool';


### PR DESCRIPTION
Fixes #18

This PR addresses the issue where the LLM tool selection was defaulting to README.md instead of using explicitly provided file paths.

Changes:
1. Updated LLM prompts to better handle explicit file paths
2. Modified path normalization logic to preserve explicit paths
3. Added regex pattern matching to extract paths from user intent
4. Enhanced logging for better debugging
5. Fixed incorrect log message in route.ts

Key improvements:
- The normalizeFilePath function now takes the original intent as a parameter
- Added path extraction from quoted strings and path-like patterns
- Explicit paths (containing '/') are preserved as-is
- Added detailed logging of path normalization
- Updated system prompts to emphasize preserving explicit paths

Testing:
1. Request a specific file (e.g., "docs/conversation01.md")
   - Should use exact path
   - Should not default to README.md
2. Request a common file without extension (e.g., "readme")
   - Should normalize to README.md
3. Request a file with quotes (e.g., "show me 'docs/file.md'")
   - Should extract and use exact path
4. Request a file with path-like pattern (e.g., "view src/components/Button.tsx")
   - Should extract and use exact path