### PR TITLE
Fix file path selection and context handling

### DIFF
--- a/app/api/tools/route/route.ts
+++ b/app/api/tools/route/route.ts
@@ -49,7 +49,7 @@ export async function POST(request: Request) {
     }
 
     // Use LLM to select tool and extract parameters
-    const { tool, parameters, confidence, reasoning } = await selectTool(intent, availableTools);
+    const { tool, parameters, confidence, reasoning } = await selectTool(intent, availableTools, context);
     
     console.log('\n=== TOOL SELECTION ===');
     console.log('Selected tool:', tool);
@@ -60,7 +60,7 @@ export async function POST(request: Request) {
 
     // Validate selection if confidence is borderline
     if (confidence >= 0.5 && confidence < 0.7) {
-      const validation = await validateToolSelection(intent, tool, parameters, availableTools);
+      const validation = await validateToolSelection(intent, tool, parameters, availableTools, context);
       
       console.log('\n=== VALIDATION ===');
       console.log('Validation result:', validation);


### PR DESCRIPTION
Fixes #18

This PR addresses the issue where the LLM tool selection was defaulting to README.md instead of using explicitly provided file paths, particularly when the path is provided in the context field.

Changes:
1. Updated LLM prompts to better handle explicit file paths and context
2. Modified path normalization logic to prioritize context paths
3. Added context parameter to selectTool and validateToolSelection functions
4. Fixed schema validation error for suggestedPrompt
5. Enhanced logging for better debugging

Key improvements:
- The normalizeFilePath function now takes context as a parameter
- Context paths are prioritized over LLM-selected paths
- Fixed schema validation by making suggestedPrompt nullable
- Added detailed logging of context and path normalization
- Updated system prompts to emphasize using context paths

Testing:
1. Request with context path:
   ```json
   {
     "intent": "read file",
     "context": "docs/conversation01.md"
   }
   ```
   - Should use exact path from context
   - Should not default to README.md

2. Request without context:
   ```json
   {
     "intent": "read readme"
   }
   ```
   - Should normalize to README.md

3. Request with quoted path:
   ```json
   {
     "intent": "show me 'docs/file.md'"
   }
   ```
   - Should extract and use exact path

4. Request with path-like pattern:
   ```json
   {
     "intent": "view src/components/Button.tsx"
   }
   ```
   - Should extract and use exact path